### PR TITLE
Use https to fix mixed content errors

### DIFF
--- a/css/splash.css
+++ b/css/splash.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Yellowtail);
+@import url(https://fonts.googleapis.com/css?family=Yellowtail);
 
 body, html {
   padding:0px;

--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
-@import url(http://fonts.googleapis.com/css?family=Yellowtail);
-@import url(http://fonts.googleapis.com/css?family=Inconsolata);
+@import url(https://fonts.googleapis.com/css?family=Yellowtail);
+@import url(https://fonts.googleapis.com/css?family=Inconsolata);
 
 body {
   padding:0px;

--- a/demos/hello-world.html
+++ b/demos/hello-world.html
@@ -3,12 +3,12 @@
   <head>
     <title>Annotorious - Image Annotation for the Web</title>
     <link href="../css/style.css" rel="stylesheet" type="text/css">
-    <link href="http://annotorious.github.io/latest/themes/dark/annotorious-dark.css" rel="stylesheet" type="text/css" />
-    <link href="http://annotorious.github.io/latest/anno-parse-plugin.css" rel="stylesheet" type="text/css" />
+    <link href="https://annotorious.github.io/latest/themes/dark/annotorious-dark.css" rel="stylesheet" type="text/css" />
+    <link href="https://annotorious.github.io/latest/anno-parse-plugin.css" rel="stylesheet" type="text/css" />
     <script type="text/javascript" src="../js/jquery-1.9.0.min.js"></script>
-    <script src="http://www.parsecdn.com/js/parse-1.2.8.min.js"></script>
-    <script type="text/javascript" src="http://annotorious.github.io/latest/annotorious.min.js"></script>
-    <script type="text/javascript" src="http://annotorious.github.io/latest/anno-parse-plugin.js"></script>
+    <script src="https://www.parsecdn.com/js/parse-1.2.8.min.js"></script>
+    <script type="text/javascript" src="https://annotorious.github.io/latest/annotorious.min.js"></script>
+    <script type="text/javascript" src="https://annotorious.github.io/latest/anno-parse-plugin.js"></script>
     <script>
       anno.addPlugin('Parse', { app_id: 'Uj3ItN35fRhtchRb00mTpIsT83JWBROFbvfwKhgn', js_key: 'wYODTTgXaPLsORyCf7HCOJrThjZvh1dm8p4Wa20P' });
     </script>

--- a/demos/okfn-plugout.html
+++ b/demos/okfn-plugout.html
@@ -5,10 +5,10 @@
     <title>Annotorious - Image Annotation for the Web</title>
     <link href="../css/style.css" rel="stylesheet" type="text/css">
     <link href="../latest/themes/dark/annotorious-dark.css" rel="stylesheet" type="text/css" />
-    <link href="http://assets.annotateit.org/annotator/v1.2.5/annotator.min.css" rel="stylesheet">
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
-    <script src="http://assets.annotateit.org/annotator/v1.2.5/annotator.min.js"></script>
-    <script src="http://annotorious.github.com/latest/annotorious.okfn.js"></script>
+    <link href="https://assets.annotateit.org/annotator/v1.2.5/annotator.min.css" rel="stylesheet">
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+    <script src="https://assets.annotateit.org/annotator/v1.2.5/annotator.min.js"></script>
+    <script src="https://annotorious.github.com/latest/annotorious.okfn.js"></script>
     <script>
       window.onload = function() {
         $('#annotatable-area').annotator().annotator('addPlugin', 'AnnotoriousImagePlugin');

--- a/demos/openlayers-annotation.html
+++ b/demos/openlayers-annotation.html
@@ -7,7 +7,7 @@
     <link type="text/css" rel="stylesheet" media="all" href="../css/highlight.css" />
     <link href="../latest/anno-parse-plugin.css" rel="stylesheet" type="text/css" />
     <script type="text/javascript" src="../js/jquery-1.9.0.min.js"></script>
-    <script src="http://www.parsecdn.com/js/parse-1.2.8.min.js"></script>
+    <script src="https://www.parsecdn.com/js/parse-1.2.8.min.js"></script>
     <script src="OpenLayers.js" type="text/javascript"></script>
     <script type="text/javascript" src="../latest/annotorious.min.js"></script>
     <script type="text/javascript" src="../latest/anno-parse-plugin.js"></script>

--- a/demos/semantic-tagging-preview.html
+++ b/demos/semantic-tagging-preview.html
@@ -3,14 +3,14 @@
   <head>
     <title>Annotorious - Image Annotation for the Web</title>
     <link href="../css/style.css" rel="stylesheet" type="text/css">
-    <link href="http://annotorious.github.io/latest/themes/dark/annotorious-dark.css" rel="stylesheet" type="text/css" />
+    <link href="https://annotorious.github.io/latest/themes/dark/annotorious-dark.css" rel="stylesheet" type="text/css" />
     <link href="semantic-tagging-plugin.css" rel="stylesheet" type="text/css" />
-    <link href="http://annotorious.github.io/latest/anno-parse-plugin.css" rel="stylesheet" type="text/css" />
+    <link href="https://annotorious.github.io/latest/anno-parse-plugin.css" rel="stylesheet" type="text/css" />
     <script type="text/javascript" src="../js/jquery-1.9.0.min.js"></script>
-    <script src="http://www.parsecdn.com/js/parse-1.2.8.min.js"></script>
-    <script type="text/javascript" src="http://annotorious.github.io/latest/annotorious.min.js"></script>
+    <script src="https://www.parsecdn.com/js/parse-1.2.8.min.js"></script>
+    <script type="text/javascript" src="https://annotorious.github.io/latest/annotorious.min.js"></script>
     <script type="text/javascript" src="semantic-tagging-plugin.js"></script>
-    <script type="text/javascript" src="http://annotorious.github.io/latest/anno-parse-plugin.js"></script>
+    <script type="text/javascript" src="https://annotorious.github.io/latest/anno-parse-plugin.js"></script>
     <script>
       anno.addPlugin('Parse', { app_id: 'Uj3ItN35fRhtchRb00mTpIsT83JWBROFbvfwKhgn', js_key: 'wYODTTgXaPLsORyCf7HCOJrThjZvh1dm8p4Wa20P' });
       anno.addPlugin('SemanticTagging', { endpoint_url: 'http://samos.mminf.univie.ac.at:8080/wikipediaminer' });


### PR DESCRIPTION
When opened **https**://annotorious.github.io/ some styles and scripts references from http resources are blocked due to mixed content error:
![2017-03-05-075130_1087x246_scrot](https://cloud.githubusercontent.com/assets/290451/23584657/9ab38466-0178-11e7-8f43-24c1cbdf7b40.png)

This pull request fixes this.